### PR TITLE
meta: Added clang-format for consistent formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+IndentWidth: 4
+UseTab: Never
+IndentCaseLabels: true
+
+AllowShortLoopsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: WithoutElse
+

--- a/src/portal.h
+++ b/src/portal.h
@@ -2,8 +2,8 @@
 #define PORTAL_H_
 
 #include <ncurses.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define WALL 'I'
 #define PLAYER 'X'
@@ -45,5 +45,4 @@ typedef enum current_portal { BLUE, ORANGE } CurrentPortal;
 void init_grid(const int rows, const int cols, char grid[rows][cols]);
 void print_grid(const int rows, const int cols, char grid[rows][cols]);
 
-#endif //PORTAL_H_
-
+#endif // PORTAL_H_


### PR DESCRIPTION
I mostly guessed the config based on the current coding style, feel free
to update it if it does't feel good to use.

Having a .clang-format allows people to use the following command:

```
clang-format -i src/*.{c,h}
```

to format the code. That way, multiple people can contribute while
keeping the code in the same style, and making sure everything is
formatted properly.

There are also plugins for most IDE to integrate clang-format and make
it easy to format the code as you write it.